### PR TITLE
feat: Add 'Copy' and 'Paste' buttons for each day

### DIFF
--- a/src/components/Header.vue
+++ b/src/components/Header.vue
@@ -23,6 +23,7 @@ const showWholeCurrentWeek = useLocalStorage(
   "showWholeCurrentWeek",
   false,
 )
+const showCopyPasteButtons = useLocalStorage("showCopyPasteButtons", false)
 
 const { totalBalance, deleteOldData, loadTimestamps, getTimestampsFromDb } =
   await useProjectTimeStore()
@@ -160,6 +161,12 @@ const openModalExport = ref(false)
             <USwitch
               v-model="showWholeCurrentWeek"
               label="Show whole current week"
+              color="success"
+              class="px-5 py-2"
+            />
+            <USwitch
+              v-model="showCopyPasteButtons"
+              label="Show copy/paste buttons"
               color="success"
               class="px-5 py-2"
             />

--- a/src/components/WorkDay.vue
+++ b/src/components/WorkDay.vue
@@ -1,3 +1,14 @@
+<script lang="ts">
+import { ref } from "vue"
+type DayClipboardEntry = {
+  timestamp: Date
+  project: string
+  description?: string
+}
+
+const dayClipboard = ref<DayClipboardEntry[] | null>(null)
+</script>
+
 <script setup lang="ts">
 import { Workday } from "../model"
 import { useProjectTimeStore } from "../store"
@@ -9,6 +20,7 @@ const { day } = defineProps<{
 }>()
 
 const { addTimestamp } = await useProjectTimeStore()
+const showCopyPasteButtons = useLocalStorage("showCopyPasteButtons", false)
 const workHoursPerDay = useLocalStorage("workHoursPerDay", 0)
 
 const colorMode = useColorMode()
@@ -63,6 +75,28 @@ function formatDate(date: Date) {
     day: "2-digit",
   })
 }
+
+function copyDay(day: Workday) {
+  dayClipboard.value = day.timestamps.map((timestamp) => ({ ...timestamp }))
+}
+
+async function pasteDay(day: Workday) {
+  if (!dayClipboard.value) return
+  for (const ts of dayClipboard.value) {
+    const newTimestamp = new Date(day.date)
+    newTimestamp.setHours(
+      ts.timestamp.getHours(),
+      ts.timestamp.getMinutes(),
+      ts.timestamp.getSeconds(),
+      ts.timestamp.getMilliseconds(),
+    )
+    try {
+      await addTimestamp(newTimestamp, ts.project, ts.description)
+    } catch (error) {
+      console.error("Error adding timestamp:", error)
+    }
+  }
+}
 </script>
 
 <template>
@@ -93,13 +127,33 @@ function formatDate(date: Date) {
           color-negative="text-red-600"
         />
       </div>
-      <UButton
-        icon="fa7-solid:plus"
-        label="Add new"
-        variant="subtle"
-        color="neutral"
-        @click="addRow(day)"
-      />
+      <div class="flex flex-row items-center gap-1">
+        <UButton
+          icon="fa7-solid:plus"
+          label="Add new"
+          variant="subtle"
+          color="neutral"
+          @click="addRow(day)"
+        />
+        <UButton
+          icon="fa7-solid:copy"
+          label="Copy"
+          variant="subtle"
+          color="neutral"
+          :disabled="day.timestamps.length === 0"
+          @click="copyDay(day)"
+          v-if="showCopyPasteButtons"
+        />
+        <UButton
+          icon="fa7-solid:paste"
+          label="Paste"
+          variant="subtle"
+          color="neutral"
+          :disabled="!dayClipboard"
+          @click="pasteDay(day)"
+          v-if="showCopyPasteButtons"
+        />
+      </div>
     </template>
     <template #footer>
       <div class="flex gap-5 px-2 items-center w-full">


### PR DESCRIPTION
Adds two new buttons on the header div of each day to copy one day's timeslots and override the ones of another day.

<img width="455" height="202" alt="image" src="https://github.com/user-attachments/assets/82eddcef-dc71-4d24-8c3b-f7d611e3a8f9" />
